### PR TITLE
Add foreign key constraints to responses table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ name = "db"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "guard",
  "model",
  "num_enum",
  "serde_json",
@@ -696,6 +697,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "guard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff893cc51ea04f8a3b73fbaf4376c06ebc5a0ccbe86d460896f805d9417c93ea"
 
 [[package]]
 name = "h2"

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -32,6 +32,9 @@ version          = "1.0.0"
 default-features = false
 features         = ["net", "rt", "sync", "rt-multi-thread", "macros", "time"]
 
+[dev-dependencies]
+guard = "0.5.1"
+
 [dev-dependencies.criterion]
 version  = "0.3"
 features = ["async_tokio", "html_reports"]

--- a/crates/db/migrations/2_responses.sql
+++ b/crates/db/migrations/2_responses.sql
@@ -3,5 +3,7 @@ CREATE TABLE IF NOT EXISTS responses (
   discord_id        INTEGER NOT NULL,
   candidate_id      INTEGER NOT NULL,
   response          BOOLEAN NOT NULL,
-  UNIQUE(discord_id, candidate_id)
+  UNIQUE(discord_id, candidate_id),
+  FOREIGN KEY(discord_id) REFERENCES users(discord_id),
+  FOREIGN KEY(candidate_id) REFERENCES users(discord_id)
 );


### PR DESCRIPTION
Ensure that `discord_id` and `candidate_id` are both present in `users`
table.