### PR TITLE
Pin Rust toolchain to 1.52.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.52.1"


### PR DESCRIPTION
This pins the rust toolchain to 1.52.1.

By sticking with a particular version of rust, we avoid issues when an upgrade breaks something or if someone tries to build with an older, unsupported version of rust, and runs into issues.