### PR TITLE
Install and check installed binary on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,5 +92,5 @@ jobs:
 
     - name: Install
       run: |
-        cargo install --path crates/quwue
+        cargo install --path .
         quwue --version

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,5 +92,5 @@ jobs:
 
     - name: Install
       run: |
-        cargo install --path .
+        cargo install --path crates/quwue
         quwue --version

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,3 +89,8 @@ jobs:
 
     - name: Check Formatting
       run: cargo +nightly fmt --all -- --check
+
+    - name: Install
+      run: |
+        cargo install --path .
+        quwue --version


### PR DESCRIPTION
Installs `quwue` on CI and checks that the installed binary works.

This ensures that the installed binary can be run, and that it has the name `quwue`.