### PR TITLE
Allow configuring logging directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /log.txt
 /crates/*/target
 /notes.md
-/crates/bot/log.txt

--- a/bin/clippy
+++ b/bin/clippy
@@ -11,4 +11,5 @@ cargo clippy --all --all-targets --all-features -- \
   --allow clippy::must-use-candidate               \
   --allow clippy::needless-lifetimes               \
   --allow clippy::non-ascii-literal                \
+  --allow clippy::option-if-let-else               \
   --allow clippy::wildcard-imports

--- a/crates/quwue/src/arguments.rs
+++ b/crates/quwue/src/arguments.rs
@@ -4,4 +4,6 @@ use crate::common::*;
 pub(crate) struct Arguments {
   #[structopt(long)]
   pub(crate) db_path: PathBuf,
+  #[structopt(long)]
+  pub(crate) log_dir: Option<PathBuf>,
 }

--- a/crates/quwue/src/bot.rs
+++ b/crates/quwue/src/bot.rs
@@ -34,9 +34,9 @@ impl Deref for Bot {
 
 impl Bot {
   pub(crate) fn main() -> Result<()> {
-    logging::init();
-
     let arguments = Arguments::from_args();
+
+    logging::init(arguments.log_dir.as_deref());
 
     let runtime = runtime::init()?;
 

--- a/crates/quwue/src/logging.rs
+++ b/crates/quwue/src/logging.rs
@@ -1,21 +1,26 @@
 use crate::common::*;
 
-pub(crate) fn init() {
-  use tracing_subscriber::fmt::Layer;
+use tracing_subscriber::fmt::Layer;
 
-  let appender = tracing_appender::rolling::never(env!("CARGO_MANIFEST_DIR"), "log.txt");
-
-  let (non_blocking, _guard) = tracing_appender::non_blocking(appender);
+pub(crate) fn init(log_dir: Option<&Path>) {
+  LogTracer::init().expect("Log tracer already set");
 
   let subscriber = tracing_subscriber::registry()
     .with(EnvFilter::from_default_env())
-    .with(Layer::new())
-    .with(Layer::new().with_ansi(false).with_writer(non_blocking));
+    .with(Layer::new());
 
-  LogTracer::init().expect("Failed to initialize log tracer");
+  if let Some(log_dir) = log_dir {
+    let appender = tracing_appender::rolling::daily(log_dir, "quwue.log");
 
-  tracing::subscriber::set_global_default(subscriber)
-    .expect("Failed to set global default tracing subscriber");
+    let (non_blocking, _guard) = tracing_appender::non_blocking(appender);
+
+    let subscriber = subscriber.with(Layer::new().with_ansi(false).with_writer(non_blocking));
+
+    tracing::subscriber::set_global_default(subscriber)
+  } else {
+    tracing::subscriber::set_global_default(subscriber)
+  }
+  .expect("Global default tracing subscriber already set");
 
   info!("Logging initialized.");
 }

--- a/crates/quwue/src/test_dispatcher.rs
+++ b/crates/quwue/src/test_dispatcher.rs
@@ -18,7 +18,7 @@ async_static! {
   test_dispatcher_value,
   TestDispatcher,
   {
-    logging::init();
+    logging::init(None);
     TestDispatcher::init().await
   }
 }


### PR DESCRIPTION
Allow configuring the logging directory with `--log-dir`. If `--log-dir` is passed, quwue will create rolling daily logs in that directory.

Also remove `crates/bot/log.txt` from `.gitignore`, since we'll no longer create that file.