### PR TITLE
Switch to second version of Rust dependency resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 publish = false
 
 [workspace]
-members = ["crates/*"]
+members  = ["crates/*"]
+resolver = "2"
 
 [dependencies]
 ansi_term               = "0.12.1"


### PR DESCRIPTION
Sönke suggested that this might fix our issues with `cargo install` not being cached.

The second version of the dependency resolver is, I believe, used by `cargo install`, so by using it for other commands, build artifacts are more likely to be shared.

We probably won't see a faster build on this PR, but would see it in subsequent PRs.

Faster or not, this is an improvement, since the second version of the dependency resolver is better.