### PR TITLE
Prioritize candidates that will match on accept2

### DIFF
--- a/crates/db/migrations/1_users.sql
+++ b/crates/db/migrations/1_users.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS users (
-  id                  INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-  discord_id          INTEGER NOT NULL UNIQUE,
-  welcomed            BOOLEAN NOT NULL DEFAULT FALSE,
-  bio                 TEXT             DEFAULT NULL
+  id         INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  discord_id INTEGER NOT NULL UNIQUE,
+  welcomed   BOOLEAN NOT NULL DEFAULT FALSE,
+  bio        TEXT             DEFAULT NULL
 );

--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -922,6 +922,11 @@ mod tests {
     let a = context.db.create_user(Prompt::Quiescent).await;
     let b = context.db.create_user(Prompt::Candidate { id: a }).await;
     let c = context.db.create_user(Prompt::Candidate { id: a }).await;
+    context.db.set_prompt(b, Prompt::Quiescent).await;
+    context.db.set_prompt(c, Prompt::Quiescent).await;
+
+    let mut tx = context.db.pool.begin().await.unwrap();
+    assert_eq!(Db::get_candidate(&mut tx, a).await.unwrap(), Some(b));
 
     let update = Update {
       action:      Some(Action::AcceptCandidate { id: a }),
@@ -935,8 +940,6 @@ mod tests {
       .commit(MessageId(0))
       .await
       .unwrap();
-
-    context.db.set_prompt(b, Prompt::Quiescent).await;
     context.db.set_prompt(c, Prompt::Quiescent).await;
 
     let mut tx = context.db.pool.begin().await.unwrap();

--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -480,8 +480,7 @@ impl Db {
     .fetch_optional(&self.pool)
     .await
     .unwrap()
-    .map(|row| row.discord_id + 1)
-    .unwrap_or(0);
+    .map_or(0, |row| row.discord_id + 1);
 
     let id = UserId(u64::load(id).unwrap());
 

--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -89,6 +89,9 @@ impl Db {
 
     let quiescent_discriminant = PromptDiscriminant::Quiescent.store();
 
+    // This should be a single SELECT with an OUTER JOIN, instead of two SELECTS,
+    // but that seems to break the sqlx query parser:
+    // https://github.com/launchbadge/sqlx/issues/1249
     let candidate = sqlx::query!(
       "SELECT
         discord_id


### PR DESCRIPTION
I took a stab at #60. The real way to do this, I think, is with an `OUTER JOIN` on users and responses, so you can do an `ORDER BY responses.response DESC` and get the users that have responded first. However, `OUTER JOIN` seems to be broken in some cases, see https://github.com/launchbadge/sqlx/issues/1249.

As a workaround, I do two selects, first only selecting candidates who have accepted, and only if that fails do I then fall back to the original select.

Until that bug gets fixed, I can't think of a better way to do this 🤷‍♀️

This might be easiest to review commit by commit. One of the commits is a refactor which should be easy to follow, but which changes a lot of code.

I also gave up making this a full test, because the full tests are slow QQ